### PR TITLE
解决iview 2.5.0 beta版本 导致 最新的tree组件与官方样例不一致的问题

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "cropperjs": "^1.1.2",
     "echarts": "^3.7.2",
     "html2canvas": "^0.5.0-beta4",
-    "iview": "^2.5.0-beta.1",
+    "iview": "^2.6.0",
     "iview-area": "^1.5.5",
     "js-cookie": "^2.1.3",
     "rasterizehtml": "^1.2.4",


### PR DESCRIPTION
由于iview-admin引用了旧版的iview，导致tree组件显示与官方样例不一致。