### PR TITLE
菜单开启手风琴模式

### DIFF
--- a/src/store/modules/app.js
+++ b/src/store/modules/app.js
@@ -8,6 +8,7 @@ const app = {
         cachePage: [],
         lang: '',
         isFullScreen: false,
+        accordion: true,
         openedSubmenuArr: [], // 要展开的菜单数组
         menuTheme: 'dark', // 主题
         themeColor: '',
@@ -104,6 +105,10 @@ const app = {
             }
             if (!hasThisName && !isEmpty) {
                 state.openedSubmenuArr.push(name);
+                if (state.accordion) {
+                    state.openedSubmenuArr.splice(0, state.openedSubmenuArr.length);
+                    state.openedSubmenuArr.push(name);
+                }
             }
         },
         closePage (state, name) {

--- a/src/views/Main.vue
+++ b/src/views/Main.vue
@@ -8,6 +8,7 @@
                 :shrink="shrink"
                 @on-change="handleSubmenuChange"
                 :theme="menuTheme" 
+                :accordion="accordion"
                 :before-push="beforePush"
                 :open-names="openedSubmenuArr"
                 :menu-list="menuList">
@@ -118,6 +119,9 @@
             },
             mesCount () {
                 return this.$store.state.app.messageCount;
+            },
+            accordion(){
+                return this.$store.state.app.accordion;
             }
         },
         methods: {

--- a/src/views/main-components/shrinkable-menu/components/sidebarMenu.vue
+++ b/src/views/main-components/shrinkable-menu/components/sidebarMenu.vue
@@ -3,7 +3,7 @@
 </style>
 
 <template>
-    <Menu ref="sideMenu" :active-name="$route.name" :open-names="openNames" :theme="menuTheme" width="auto" @on-select="changeMenu">
+    <Menu ref="sideMenu" :accordion="accordion" :active-name="$route.name" :open-names="openNames" :theme="menuTheme" width="auto" @on-select="changeMenu">
         <template v-for="item in menuList">
             <MenuItem v-if="item.children.length<=1" :name="item.children[0].name" :key="'menuitem' + item.name">
                 <Icon :type="item.children[0].icon || item.icon" :size="iconSize" :key="'menuicon' + item.name"></Icon>
@@ -38,6 +38,10 @@ export default {
         },
         openNames: {
             type: Array
+        },
+        accordion: {
+            type: Boolean,
+            default: false
         }
     },
     methods: {

--- a/src/views/main-components/shrinkable-menu/shrinkable-menu.vue
+++ b/src/views/main-components/shrinkable-menu/shrinkable-menu.vue
@@ -8,6 +8,7 @@
         <sidebar-menu 
             v-show="!shrink"
             :menu-theme="theme" 
+            :accordion="accordion"
             :menu-list="menuList" 
             :open-names="openNames"
             @on-change="handleChange"
@@ -53,6 +54,10 @@ export default {
         },
         openNames: {
             type: Array
+        },
+        accordion: {
+            type: Boolean,
+            default: false
         }
     },
     computed: {


### PR DESCRIPTION
通过修改iview中src/components/menu/menu.vue源码可以实现"标签选项"切换时菜单手风琴模式不起作用的bug
![image](https://user-images.githubusercontent.com/23071957/35279222-64d603c8-0087-11e8-82fa-3ba69aacfe0b.png)
