### PR TITLE
Fix 'SideMenuItem is not defined'

### DIFF
--- a/src/view/main/components/side-menu/side-menu.vue
+++ b/src/view/main/components/side-menu/side-menu.vue
@@ -24,8 +24,8 @@
   </div>
 </template>
 <script>
-import sideMenuItem from './side-menu-item.vue'
-import collapsedMenu from './collapsed-menu.vue'
+import SideMenuItem from './side-menu-item.vue'
+import CollapsedMenu from './collapsed-menu.vue'
 import { getUnion } from '@/libs/tools'
 import mixin from './mixin'
 


### PR DESCRIPTION
```
npm i

npm run dev

```

there is an error in the console panel 'SideMenuItem is not defined',  and the page is not displayed as we expected.

