### PR TITLE
修复nodejs版本大于10时的构建问题

### DIFF
--- a/build/webpack.dev.config.js
+++ b/build/webpack.dev.config.js
@@ -9,7 +9,11 @@ const package = require('../package.json');
 
 fs.open('./build/env.js', 'w', function(err, fd) {
     const buf = 'export default "development";';
-    fs.write(fd, buf, 0, buf.length, 0, function(err, written, buffer) {});
+    if (process.version >= 'v10.0.0') {
+        fs.write(fd, buf, 0, 'utf-8', function(err, written, buffer) {});
+    } else {
+        fs.write(fd, buf, 0, buf.length, 0, function(err, written, buffer) {});
+    }
 });
 
 module.exports = merge(webpackBaseConfig, {

--- a/build/webpack.prod.config.js
+++ b/build/webpack.prod.config.js
@@ -13,7 +13,11 @@ const package = require('../package.json');
 
 fs.open('./build/env.js', 'w', function(err, fd) {
     const buf = 'export default "production";';
-    fs.write(fd, buf, 0, buf.length, 0, function(err, written, buffer) {});
+    if (process.version >= 'v10.0.0') {
+        fs.write(fd, buf, 0, 'utf-8', function(err, written, buffer) {});
+    } else {
+        fs.write(fd, buf, 0, buf.length, 0, function(err, written, buffer) {});
+    }
 });
 
 module.exports = merge(webpackBaseConfig, {


### PR DESCRIPTION
当nodejs版本大于10时，fs中的write方法参数发生变化。导致构建dev和build时报错。