### PR TITLE
tables component允许设置列是否支持搜索以及自定义搜索方法

### DIFF
--- a/src/components/tables/tables.vue
+++ b/src/components/tables/tables.vue
@@ -2,7 +2,7 @@
   <div>
     <div v-if="searchable && searchPlace === 'top'" class="search-con search-con-top">
       <Select v-model="searchKey" class="search-col">
-        <Option v-for="item in columns" v-if="item.key !== 'handle'" :value="item.key" :key="`search-col-${item.key}`">{{ item.title }}</Option>
+        <Option v-for="item in columns" v-if="item.key !== 'handle' && item.searchable && item.title" :value="item.key" :key="`search-col-${item.key}`">{{ item.title }}</Option>
       </Select>
       <Input @on-change="handleClear" clearable placeholder="输入关键字搜索" class="search-input" v-model="searchValue"/>
       <Button @click="handleSearch" class="search-btn" type="primary"><Icon type="search"/>&nbsp;&nbsp;搜索</Button>
@@ -40,7 +40,7 @@
     </Table>
     <div v-if="searchable && searchPlace === 'bottom'" class="search-con search-con-top">
       <Select v-model="searchKey" class="search-col">
-        <Option v-for="item in columns" v-if="item.key !== 'handle'" :value="item.key" :key="`search-col-${item.key}`">{{ item.title }}</Option>
+        <Option v-for="item in columns" v-if="item.key !== 'handle' && item.searchable && item.title" :value="item.key" :key="`search-col-${item.key}`">{{ item.title }}</Option>
       </Select>
       <Input placeholder="输入关键字搜索" class="search-input" v-model="searchValue"/>
       <Button class="search-btn" type="primary"><Icon type="search"/>&nbsp;&nbsp;搜索</Button>
@@ -206,13 +206,19 @@ export default {
       })
     },
     setDefaultSearchKey () {
-      this.searchKey = this.columns[0].key !== 'handle' ? this.columns[0].key : (this.columns.length > 1 ? this.columns[1].key : '')
+      let column = this.columns.find(column => column.key !== 'handle' && column.searchable && column.title)
+      if (column) this.searchKey = column.key
     },
     handleClear (e) {
       if (e.target.value === '') this.insideTableData = this.value
     },
     handleSearch () {
-      this.insideTableData = this.value.filter(item => item[this.searchKey].indexOf(this.searchValue) > -1)
+      if (this.searchKey) this.insideTableData = this.value.filter(item => item[this.searchKey].indexOf(this.searchValue) > -1)
+      let params = {
+        key: this.searchKey,
+        value: this.searchValue
+      }
+      this.$emit('on-search', params)
     },
     handleTableData () {
       this.insideTableData = this.value.map((item, index) => {

--- a/src/view/components/tables/tables.vue
+++ b/src/view/components/tables/tables.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <Card>
-      <tables ref="tables" editable searchable search-place="top" v-model="tableData" :columns="columns" @on-delete="handleDelete"/>
+      <tables ref="tables" editable searchable search-place="top" v-model="tableData" :loading="loading" :columns="columns" @on-delete="handleDelete" @on-search="handleSearch"/>
       <Button style="margin: 10px 0;" type="primary" @click="exportExcel">导出为Csv文件</Button>
     </Card>
   </div>
@@ -17,10 +17,11 @@ export default {
   },
   data () {
     return {
+      loading: false,
       columns: [
-        {title: 'Name', key: 'name', sortable: true},
-        {title: 'Email', key: 'email', editable: true},
-        {title: 'Create-Time', key: 'createTime'},
+        {title: 'Name', key: 'name', sortable: true, searchable: true},
+        {title: 'Email', key: 'email', editable: true, searchable: true},
+        {title: 'Create-Time', key: 'createTime', searchable: true},
         {
           title: 'Handle',
           key: 'handle',
@@ -51,6 +52,13 @@ export default {
   methods: {
     handleDelete (params) {
       console.log(params)
+    },
+    handleSearch (params) {
+      // 在这里模拟进行远程过滤
+      this.loading = true
+      setTimeout(() => {
+        this.loading = false
+      }, 1000)
     },
     exportExcel () {
       this.$refs.tables.exportCsv({


### PR DESCRIPTION
1. 有些时候我们需要进行后台的搜索, 而不只是简单的前台过滤
2. 有些时候对于某些列, 可能后台API不支持对其进行搜索

改动之后:
1. 默认情况下列不支持搜索, 除非指定searchable为true
2. title为空的列不会纳入搜索范畴，用于过滤掉类似type为selection的列