### PR TITLE
修复页面切换导致的动态路由参数丢失问题

### DIFF
--- a/src/libs/util.js
+++ b/src/libs/util.js
@@ -114,10 +114,10 @@ export const getHomeRoute = routers => {
  * @description 如果该newRoute已经存在则不再添加
  */
 export const getNewTagList = (list, newRoute) => {
-  const { name, path, meta } = newRoute
+  const { name, path, meta, params, query } = newRoute
   let newList = [...list]
   if (newList.findIndex(item => item.name === name) >= 0) return newList
-  else newList.push({ name, path, meta })
+  else newList.push({ name, path, meta, params, query })
   return newList
 }
 

--- a/src/view/main/main.vue
+++ b/src/view/main/main.vue
@@ -111,7 +111,11 @@ export default {
       else if (this.$route.name === name) this.$router.push({ name: nextName })
     },
     handleClick (item) {
-      this.turnToPage(item.name)
+      let routerObj = {}
+      routerObj.name = item.name
+      if (item.params) routerObj.params = item.params
+      if (item.query) routerObj.query = item.query
+      this.$router.push(routerObj)
     }
   },
   watch: {


### PR DESCRIPTION
举个栗子，操作步骤如下:

1. 打开一个订单的详情页(动态路由), 然后路径为/order/1，可以看到编号为1的订单详情；

2. 打开另一个页面

3. 通过tag再次切换回编号为1的订单详情页面，发现url为空且参数已经丢失了(即通过`$route.params`已经获取不到订单编号了)