### PR TITLE
解决页面缓存meta设置无效的问题

### DIFF
--- a/src/view/main/main.vue
+++ b/src/view/main/main.vue
@@ -23,9 +23,10 @@
             <tags-nav :value="$route" @input="handleClick" :list="tagNavList" @on-close="handleCloseTag"/>
           </div>
           <Content class="content-wrapper">
-            <keep-alive :include="cacheList">
-              <router-view/>
+            <keep-alive>
+              <router-view v-if="!($route.meta && $route.meta.notCache)"></router-view>
             </keep-alive>
+            <router-view v-if="$route.meta && $route.meta.notCache"></router-view>
           </Content>
         </Layout>
       </Content>
@@ -71,9 +72,6 @@ export default {
     },
     userAvator () {
       return this.$store.state.user.avatorImgPath
-    },
-    cacheList () {
-      return this.tagNavList.length ? this.tagNavList.filter(item => !(item.meta && item.meta.notCache)).map(item => item.name) : []
     },
     menuList () {
       return this.$store.getters.menuList


### PR DESCRIPTION
keep-alive的include属性用于存放待缓存的组件名，目前的代码存的是route名，所以只有在route名和组件名恰好一致的情况下，noCache为false(默认为缓存页面)才能正常工作

测试步骤：

1. 新增一个route，其name和所使用的组件名不一致

2. 运行后，点击打开此route对应的页面，然后在某个文本框输入`123`

3. 切换到其他页面

4. 再次切换回来，可以发现文本框输入的`123`丢失了

需求场景：

1. 我们一般不会刻意去让route名和组件名一致，除非有明确的文档说明

2. 我们可能在不同的route下复用相同的组件，譬如进行权限管理，有多个角色都具备相同的功能，但是我们希望url有所不同；这时就没办法让route名都和组件名一致了，不然会报warn