### PR TITLE
修复markdown-editor组件无法设置初始值以及无法真正双向绑定value

### DIFF
--- a/src/components/markdown/markdown.vue
+++ b/src/components/markdown/markdown.vue
@@ -8,7 +8,7 @@
 import Simplemde from 'simplemde'
 import 'simplemde/dist/simplemde.min.css'
 export default {
-  naem: 'MarkdownEditor',
+  name: 'MarkdownEditor',
   props: {
     value: {
       type: String,
@@ -48,7 +48,8 @@ export default {
   },
   mounted () {
     this.editor = new Simplemde(Object.assign(this.options, {
-      element: this.$refs.editor
+      element: this.$refs.editor,
+      initialValue: this.value
     }))
     /**
      * 事件列表为Codemirror编辑器的事件，更多事件类型，请参考：
@@ -57,6 +58,12 @@ export default {
     this.addEvents()
     let content = localStorage.markdownContent
     if (content) this.editor.value(content)
+  },
+  watch: {
+    value (val) {
+      if (val === this.editor.value()) return
+      this.editor.value(val)
+    }
   }
 }
 </script>


### PR DESCRIPTION
**1. 目前设置初始值不生效
2. 修改双向绑定的value时，编辑器的内容不会一起变化**

复现步骤, 我的代码如下：
```
<FormItem label="文章内容" prop="content">
              <markdown-editor v-model="form.content"
                               :localCache="false"/>
            </FormItem>

form: {
        content: 'this is the init value'
      }
```
我发现了2个问题：
1.  编辑器的内容初始是为空的，也就是我的初始值没起作用
2. 后面我尝试清空编辑器内容，于是我设置form.content = '' 发现也不起作用
