### PR TITLE
Bugfix: 修复从URL开启动态路由页面时，不会增加标签

### DIFF
--- a/src/store/module/app.js
+++ b/src/store/module/app.js
@@ -21,9 +21,19 @@ export default {
       } else state.tagNavList = getTagNavListFromLocalstorage()
     },
     addTag (state, { route, type = 'unshift' }) {
+      state.tagNavList = getTagNavListFromLocalstorage()
       if (!routeHasExist(state.tagNavList, route)) {
-        if (type === 'push') state.tagNavList.push(route)
-        else {
+        if (type === 'push') {
+          const tagIndex = state.tagNavList.findIndex(v => v.name === route.name)
+          if (tagIndex && state.tagNavList[tagIndex]) {
+            const isParamsOrQuery = ['params', 'query'].some(v => state.tagNavList[tagIndex][v])
+            if (!isParamsOrQuery) {
+              state.tagNavList.splice(tagIndex, 1, route)
+            } else state.tagNavList.push(route)
+          } else {
+            state.tagNavList.push(route)
+          }
+        } else {
           if (route.name === 'home') state.tagNavList.unshift(route)
           else state.tagNavList.splice(1, 0, route)
         }

--- a/src/view/argu-page/params.vue
+++ b/src/view/argu-page/params.vue
@@ -7,8 +7,43 @@
 </template>
 
 <script>
+import { mapMutations } from 'vuex'
 export default {
-  name: 'argu_page'
+  name: 'params',
+  watch: {
+    '$route.path' () {
+      this.addRouteTag()
+    }
+  },
+  computed: {
+    componentName () {
+      return this.$vnode.tag.replace(/^vue-component-\d*-/, '')
+    }
+  },
+  methods: {
+    ...mapMutations([
+      'addTag'
+    ]),
+    addRouteTag () {
+      if (this.$route.name === this.componentName) {
+        const { name, params } = this.$route
+        const route = {
+          name,
+          params,
+          meta: {
+            title: `动态路由-${params.id}`
+          }
+        }
+        this.addTag({
+          route,
+          type: 'push'
+        })
+      }
+    }
+  },
+  created () {
+    this.addRouteTag()
+  }
 }
 </script>
 

--- a/src/view/argu-page/query.vue
+++ b/src/view/argu-page/query.vue
@@ -7,8 +7,43 @@
 </template>
 
 <script>
+import { mapMutations } from 'vuex'
 export default {
-  name: 'query'
+  name: 'query',
+  watch: {
+    '$route.path' () {
+      this.addRouteTag()
+    }
+  },
+  computed: {
+    componentName () {
+      return this.$vnode.tag.replace(/^vue-component-\d*-/, '')
+    }
+  },
+  methods: {
+    ...mapMutations([
+      'addTag'
+    ]),
+    addRouteTag () {
+      if (this.$route.name === this.componentName) {
+        const { name, query } = this.$route
+        const route = {
+          name,
+          query,
+          meta: {
+            title: `参数-${query.id}`
+          }
+        }
+        this.addTag({
+          route,
+          type: 'push'
+        })
+      }
+    }
+  },
+  created () {
+    this.addRouteTag()
+  }
 }
 </script>
 

--- a/src/view/tools-methods/tools-methods.vue
+++ b/src/view/tools-methods/tools-methods.vue
@@ -3,7 +3,7 @@
     <Card shadow>
       <Row>
         <i-col span="4">
-          <Button @click="createTagParams">添加一个标签</Button>
+          <Button @click="createParamsRoute()">添加一个标签</Button>
         </i-col>
         <i-col span="20">
           <p>动态路由，添加params</p>
@@ -13,7 +13,7 @@
     <Card shadow style="margin-top: 10px;">
       <Row>
         <i-col span="4">
-          <Button @click="createTagQuery">添加一个标签</Button>
+          <Button @click="createQueryRoute()">添加一个标签</Button>
         </i-col>
         <i-col span="20">
           <p>动态路由，添加query</p>
@@ -24,46 +24,26 @@
 </template>
 
 <script>
-import { mapMutations } from 'vuex'
 export default {
   name: 'tools_methods_page',
   methods: {
-    ...mapMutations([
-      'addTag'
-    ]),
-    createTagParams () {
+    createParamsRoute () {
       const id = parseInt(Math.random() * 100000)
-      const route = {
+      this.$router.push({
         name: 'params',
         params: {
           id
-        },
-        meta: {
-          title: `动态路由-${id}`
         }
-      }
-      this.addTag({
-        route: route,
-        type: 'push'
       })
-      this.$router.push(route)
     },
-    createTagQuery () {
+    createQueryRoute () {
       const id = parseInt(Math.random() * 100000)
-      const route = {
+      this.$router.push({
         name: 'query',
         query: {
           id
-        },
-        meta: {
-          title: `参数-${id}`
         }
-      }
-      this.addTag({
-        route: route,
-        type: 'push'
       })
-      this.$router.push(route)
     }
   }
 }


### PR DESCRIPTION
我把tools-methods.vue中的addTag(增加标签)移到params.vue和query.vue里，
变成只要进入params.vue(或query.vue)时即触发addTag(增加标签)。

但总是都会多一个没有params(或query)的标签，所以在addTag里过滤路由：
若准备要增加标签的路由的Name已在标签列表里出现，且不包含params(或query)，(符合以上条件的就是多的标签)就把这个路由替换成新的路由(含有params或query) 。