### PR TITLE
增加带分页的表格和可以加载远程数据的表格

### DIFF
--- a/src/api/data.js
+++ b/src/api/data.js
@@ -13,3 +13,15 @@ export const getDragList = () => {
     method: 'get'
   })
 }
+export const getPageTableData = ({ index, size }) => {
+  debugger
+  const data = {
+    index,
+    size
+  }
+  return axios.request({
+    url: 'get_page_table_data',
+    data,
+    method: 'get'
+  })
+}

--- a/src/components/remote-table/page-table.js
+++ b/src/components/remote-table/page-table.js
@@ -1,0 +1,120 @@
+import {
+  Table,
+  Page
+} from 'iview'
+export default {
+  name: 'page-table',
+  render: function (h) {
+    let tableProps = {}
+    for (let prop in Table.props) {
+      if (prop === 'data') {
+        tableProps[prop] = this.tableData
+      } else {
+        tableProps[prop] = this[prop]
+      }
+    }
+    let pageProps = {}
+    for (let prop in Page.props) {
+      if (prop === 'current') {
+        pageProps[prop] = this.pageCurrent
+      } else if (prop === 'total') {
+        pageProps[prop] = this.pageTotal
+      } else {
+        pageProps[prop] = this[prop]
+      }
+    }
+
+    if (pageProps['size'] && pageProps['size'] !== 'small') {
+      delete pageProps['size']
+    }
+    let header = this.$slots.header === undefined ? undefined : h('slot', {
+      slot: 'header'
+    }, this.$slots.header)
+    var page = this.showPage ? h(Page, {
+      props: pageProps,
+      ref: this.pageRefs,
+      on: {
+        'update:current': val => { this.pageCurrent = val }
+      }
+    }) : undefined
+    let footer = this.$slots.footer === undefined && page === undefined ? undefined : h('slot', {
+      slot: 'footer'
+    }, [this.$slots.footer, page])
+    let loading = this.$slots.loading === undefined ? undefined : h('slot', {
+      slot: 'loading'
+    }, [this.$slots.loading])
+
+    return h(Table, {
+      props: tableProps,
+      ref: this.tableRefs
+    }, [header, footer, loading])
+  },
+  props: (() => {
+    var props = {}
+    Object.assign(props, Page.props, Table.props, {
+      showPage: {
+        type: Boolean,
+        default () {
+          return true
+        }
+      },
+      tableRefs: {
+        type: String,
+        default () {
+          return '_table'
+        }
+      },
+      pageRefs: {
+        type: String,
+        default () {
+          return '_page'
+        }
+      }
+    })
+    return props
+  })(),
+  computed: {
+    tableData: function () {
+      return this.data
+    }
+  },
+  data () { // 自带属性值
+    return {
+      pageCurrent: this.current,
+      mPageSize: this.pageSize,
+      pageTotal: this.total,
+      tableEvents: ['on-current-change', 'on-row-click', 'on-row-dblclick',
+        'on-select', 'on-select-cancel', 'on-selection-change', 'on-expand',
+        'on-select-all', 'on-filter-change', 'on-sort-change'
+      ],
+      pageEvents: ['on-change', 'on-page-size-change']
+    }
+  },
+  methods: {
+    bindTableEvent: function () {
+      let _this = this
+      let table = this.$refs[this.$props.tableRefs]
+      this.tableEvents.forEach(event => {
+        table.$on(event, function () {
+          _this.$emit(event, ...arguments)
+        })
+      })
+    },
+    bindPageEvent: function () {
+      let _this = this
+      let page = this.$refs[this.$props.pageRefs]
+      this.pageEvents.forEach(event => {
+        page.$on(event, function () {
+          if (event === 'on-change') {
+            _this.$emit('update:current', _this.pageCurrent)
+          }
+          _this.$emit(event, ...arguments)
+        })
+      })
+    }
+  },
+  mounted () {
+    this.bindTableEvent()
+    this.bindPageEvent()
+  }
+}

--- a/src/components/remote-table/remote-table.js
+++ b/src/components/remote-table/remote-table.js
@@ -1,0 +1,58 @@
+import PageTable from './page-table.js'
+const TOTAL = 'total'
+const ITEMS = 'items'
+
+export default {
+  name: 'remote-table',
+  extends: PageTable,
+  props: {
+    dataRemote: Function
+  },
+  data () { // 自带属性值
+    return {
+      mData: []
+    }
+  },
+  methods: {
+    load: function () {
+      if (this.dataRemote) {
+        let pageIndex = this.pageCurrent
+        let pageSize = this.mPageSize
+        this.$emit('on-before-load', this.mData)
+        let promise = this.dataRemote(pageIndex, pageSize)
+        promise && promise.then(res => {
+          this.loadData(res.data)
+        })
+      }
+    },
+    loadData: function (data) {
+      this.pageTotal = data[TOTAL]
+      this.mData = data[ITEMS]
+      this.$emit('update:data', this.mData)
+      this.$emit('on-loaded', this.mData)
+    },
+    bindPageEvent: function () {
+      let _this = this
+
+      let page = this.$refs[this.$props.pageRefs]
+      page.$on('on-change', function (val) {
+        _this.$emit('update:current', val)
+        _this.$emit('on-change', ...arguments)
+        _this.load()
+      })
+      page.$on('on-page-size-change', function (val) {
+        _this.mPageSize = val
+        _this.$emit('on-page-size-change', ...arguments)
+        _this.load()
+      })
+    }
+  },
+  computed: {
+    tableData: function () {
+      return this.mData
+    }
+  },
+  mounted () {
+    this.load()
+  }
+}

--- a/src/mock/data.js
+++ b/src/mock/data.js
@@ -24,3 +24,20 @@ export const getDragList = req => {
   })
   return dragList
 }
+const total = 34
+export const getPageTableData = req => {
+  req = JSON.parse(req.body)
+  let index = req.index || 1
+  let size = req.size || 10
+  let returnCount = total - size * (index - 1)
+  returnCount = returnCount > size ? size : returnCount
+  let tableData = []
+  doCustomTimes(returnCount, () => {
+    tableData.push(Mock.mock({
+      name: '@name',
+      email: '@email',
+      createTime: '@date'
+    }))
+  })
+  return { total: total, items: tableData }
+}

--- a/src/mock/index.js
+++ b/src/mock/index.js
@@ -1,6 +1,6 @@
 import Mock from 'mockjs'
 import { login, logout, getUserInfo } from './login'
-import { getTableData, getDragList } from './data'
+import { getTableData, getDragList, getPageTableData } from './data'
 
 // 登录相关和获取用户信息
 Mock.mock(/\/login/, login)
@@ -8,5 +8,6 @@ Mock.mock(/\/get_info/, getUserInfo)
 Mock.mock(/\/logout/, logout)
 Mock.mock(/\/get_table_data/, getTableData)
 Mock.mock(/\/get_drag_list/, getDragList)
+Mock.mock(/\/get_page_table_data/, getPageTableData)
 
 export default Mock

--- a/src/router/routers.js
+++ b/src/router/routers.js
@@ -105,6 +105,15 @@ export default [
         component: () => import('@/view/components/tables/tables.vue')
       },
       {
+        path: 'remote_table_page',
+        name: 'remote_table_page',
+        meta: {
+          icon: 'md-grid',
+          title: '远程数据表格'
+        },
+        component: () => import('@/view/components/remote-table/remote-table.vue')
+      },
+      {
         path: 'split_pane_page',
         name: 'split_pane_page',
         meta: {

--- a/src/view/components/remote-table/remote-table.vue
+++ b/src/view/components/remote-table/remote-table.vue
@@ -1,0 +1,46 @@
+<template>
+  <page-table @on-loaded="handleLoaded" :columns="columns1" :data.sync="data1" :data-remote="getPageData" :page-size="pageSize" :current.sync="current">
+  </page-table>
+</template>
+<script>
+import PageTable from '_c/remote-table/remote-table.js'
+import {
+  getPageTableData
+} from '@/api/data'
+export default {
+  components: {
+    PageTable
+  },
+  data () {
+    return {
+      current: 2,
+      pageSize: 10,
+      columns1: [{
+        title: 'Name',
+        key: 'name',
+        sortable: true
+      },
+      {
+        title: 'Email',
+        key: 'email',
+        editable: true
+      },
+      {
+        title: 'Create-Time',
+        key: 'createTime'
+      }
+      ],
+      data1: []
+    }
+  },
+  methods: {
+    getPageData: function (index, size) {
+      return getPageTableData({
+        index,
+        size
+      })
+    },
+    handleLoaded: function () {}
+  }
+}
+</script>


### PR DESCRIPTION
增加带分页表格组件page-table，它继承iview的table和page的所有属性和事件，新增属性showPage，是否显示分页组件，默认为ture
增加可加载远程表格组件remote-table，继承page-table，新增属性dataRemote，类型为Function，返回值为Promise，为加载远程数据方法，增加on-before-load事件和on-loaded事件，远程表格组件中data不再有效，但是可以通过data.sync来获取当前表格数据