### PR TITLE
bug修复：多功能表格组件，编辑某一格时如果没有做任何更改直接保存，原有数据会被清空

### DIFF
--- a/src/components/tables/tables.vue
+++ b/src/components/tables/tables.vue
@@ -166,6 +166,7 @@ export default {
               this.edittingText = val
             },
             'on-start-edit': (params) => {
+              this.edittingText = this.value[params.row.initRowIndex][params.column.key]
               this.edittingCellId = `editting-${params.index}-${params.column.key}`
               this.$emit('on-start-edit', params)
             },
@@ -176,7 +177,7 @@ export default {
             'on-save-edit': (params) => {
               this.value[params.row.initRowIndex][params.column.key] = this.edittingText
               this.$emit('input', this.value)
-              this.$emit('on-save-edit', Object.assign(params, {value: this.edittingText}))
+              this.$emit('on-save-edit', Object.assign(params, { value: this.edittingText }))
               this.edittingCellId = ''
             }
           }


### PR DESCRIPTION
在tables.vue文件中on-start-edit方法添加一行代码

`this.edittingText = this.value[params.row.initRowIndex][params.column.key]`

修改后代码如下
```
            'on-start-edit': (params) => {
              this.edittingText = this.value[params.row.initRowIndex][params.column.key]
              this.edittingCellId = `editting-${params.index}-${params.column.key}`
              this.$emit('on-start-edit', params)
            },
```