### PR TITLE
修复可编辑表格数据丢失

### DIFF
--- a/src/components/tables/edit.vue
+++ b/src/components/tables/edit.vue
@@ -32,6 +32,7 @@ export default {
     },
     startEdit () {
       this.$emit('on-start-edit', this.params)
+      this.$emit('input', this.value)
     },
     saveEdit () {
       this.$emit('on-save-edit', this.params)


### PR DESCRIPTION
可编辑表格在不进行修改的情况下保存，会丢失数据。