### PR TITLE
Fix router key duplicate when home router is not hiden in menu

### DIFF
--- a/src/libs/util.js
+++ b/src/libs/util.js
@@ -12,7 +12,7 @@ export const setToken = (token) => {
 export const getToken = () => {
   const token = Cookies.get(TOKEN_KEY)
   if (token) return token
-  else return false
+  else return ''
 }
 
 export const hasChild = (item) => {
@@ -64,7 +64,11 @@ export const getBreadCrumbList = (routeMetched, homeRoute) => {
     return obj
   })
   res = res.filter(item => {
-    return !item.meta.hideInMenu
+    if (item.name === 'home') {
+      return false
+    } else {
+      return !item.meta.hideInMenu
+    }
   })
   return [Object.assign(homeRoute, { to: homeRoute.path }), ...res]
 }


### PR DESCRIPTION
1. when can not find token, we should return empty string, not 'false'
2. home route will be added finally, so should filter home route out to avoid duplicate key error in console 