### PR TITLE
可编辑表格在单元格内容为空时，需要占位符或者最小高度，否则dom没有高度，鼠标悬浮出现不了编辑按钮

### DIFF
--- a/src/components/tables/edit.vue
+++ b/src/components/tables/edit.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="tables-edit-outer">
     <div v-if="!isEditting" class="tables-edit-con">
-      <span class="value-con">{{ value }}</span>
+      <span class="value-con">&ensp;{{ value }}&ensp;</span>
       <Button v-if="editable" @click="startEdit" class="tables-edit-btn" style="padding: 2px 4px;" type="text"><Icon type="md-create"></Icon></Button>
     </div>
     <div v-else class="tables-editting-con">

--- a/src/view/single-page/home/example.vue
+++ b/src/view/single-page/home/example.vue
@@ -104,11 +104,11 @@ export default {
     this.$nextTick(() => {
       this.dom = echarts.init(this.$refs.dom)
       this.dom.setOption(option)
-      on(window, 'resize', this.resize())
+      on(window, 'resize', this.resize)
     })
   },
   beforeDestroy () {
-    off(window, 'resize', this.resize())
+    off(window, 'resize', this.resize)
   }
 }
 </script>


### PR DESCRIPTION
可编辑表格在单元格内容为空时，需要占位符或者最小高度，否则dom没有高度，鼠标悬浮出现不了编辑按钮；example.vue中的图表绑定window.resize传参有问题，应该传函数本身