### PR TITLE
优化side-menu组件

### DIFF
--- a/src/components/main/components/side-menu/side-menu.vue
+++ b/src/components/main/components/side-menu/side-menu.vue
@@ -4,8 +4,7 @@
     <Menu ref="menu" v-show="!collapsed" :active-name="activeName" :open-names="openedNames" :accordion="accordion" :theme="theme" width="auto" @on-select="handleSelect">
       <template v-for="item in menuList">
         <template v-if="item.children && item.children.length === 1">
-          <side-menu-item v-if="showChildren(item)" :key="`menu-${item.name}`" :parent-item="item"></side-menu-item>
-          <menu-item v-else :name="getNameOrHref(item, true)" :key="`menu-${item.children[0].name}`"><common-icon :type="item.children[0].icon || ''"/><span>{{ showTitle(item.children[0]) }}</span></menu-item>
+          <menu-item :name="getNameOrHref(item, true)" :key="`menu-${item.children[0].name}`"><common-icon :type="item.children[0].icon || ''"/><span>{{ showTitle(item.children[0]) }}</span></menu-item>
         </template>
         <template v-else>
           <side-menu-item v-if="showChildren(item)" :key="`menu-${item.name}`" :parent-item="item"></side-menu-item>


### PR DESCRIPTION
在`item.children && item.children.length === 1`条件下，由于`<side-menu-item/>`组件中进行了`showChildren(item)`函数判断，发现该函数包含了`item.children && item.children.length > 1 `的判断逻辑，所以在上面条件下的`<slde-menu-item/>`组件永远不会渲染，觉得可以去掉，让整体结构更加清晰一点。