### PR TITLE
增加如新建页详情页等隐藏左侧菜单选项但是需要显示面包屑导航功能

### DIFF
--- a/src/libs/util.js
+++ b/src/libs/util.js
@@ -69,7 +69,7 @@ export const getBreadCrumbList = (route, homeRoute) => {
     return obj
   })
   res = res.filter(item => {
-    return !item.meta.hideInMenu
+    return item.meta.needInBread ? true : !item.meta.hideInMenu
   })
   return [{...homeItem, to: homeRoute.path}, ...res]
 }

--- a/src/router/routers.js
+++ b/src/router/routers.js
@@ -10,6 +10,7 @@ import parentView from '@/components/parent-view'
  *         可以传入一个回调函数，参数是当前路由对象，例子看动态路由和带参路由
  *  hideInBread: (false) 设为true后此级路由将不会出现在面包屑中，示例看QQ群路由配置
  *  hideInMenu: (false) 设为true后在左侧菜单不会显示该页面选项
+ *  needInBread: (false) 如新建页详情页等隐藏左侧菜单选项但是需要显示面包屑导航
  *  notCache: (false) 设为true后页面在切换标签后不会缓存，如果需要缓存，无需设置这个字段，而且需要设置页面组件name属性和路由配置的name一致
  *  access: (null) 可访问该页面的权限数组，当前路由设置的权限会影响子路由
  *  icon: (-) 该页面在左侧菜单、面包屑和标签导航处显示的图标，如果是自定义图标，需要在图标名称前加下划线'_'


### PR DESCRIPTION
当在左侧菜单栏显示列表页时，同时需要不在左侧菜单栏显示的新建页，编辑页，详情页等。
新建页，编辑页，详情页不需要显示在左侧菜单，但是需要显示相应面包屑。
vuex中的面包屑列表只过滤了hideMenu情况，无法提供只需要面包屑但是不需要左侧菜单栏显示的功能。