### PR TITLE
:pencil2: 别名配置@为cli3自带功能，注释掉

### DIFF
--- a/vue.config.js
+++ b/vue.config.js
@@ -31,7 +31,7 @@ module.exports = {
   lintOnSave: true,
   chainWebpack: config => {
     config.resolve.alias
-      .set('@', resolve('src')) // key,value自行定义，比如.set('@@', resolve('src/components'))
+      //.set('@', resolve('src')) // key,value自行定义，比如.set('@@', resolve('src/components'))
       .set('_c', resolve('src/components'))
   },
   // 设为false打包时不生成.map文件


### PR DESCRIPTION
别名配置@为cli3自带功能，没必要在配置文件里配置