### PR TITLE
修复获取 homeRoute 错误

### DIFF
--- a/src/libs/util.js
+++ b/src/libs/util.js
@@ -122,7 +122,7 @@ export const getTagNavListFromLocalstorage = () => {
  * @param {Array} routers 路由列表数组
  * @description 用于找到路由列表中name为home的对象
  */
-export const getHomeRoute = (routers, homeName = 'home') => {
+export const getHomeRoute = (routers, homeName = config.homeName) => {
   let i = -1
   let len = routers.length
   let homeRoute = {}


### PR DESCRIPTION
当修改 config 中的 homeName 为其他名称时，默认参数为 home 就可能会导致获取 home 路由错误。