### PR TITLE
fix bug #1216

### DIFF
--- a/src/components/tables/edit.vue
+++ b/src/components/tables/edit.vue
@@ -49,6 +49,7 @@ export default {
   .tables-edit-con{
     position: relative;
     height: 100%;
+    min-height: 20px;
     .value-con{
       vertical-align: middle;
     }

--- a/src/components/tables/tables.vue
+++ b/src/components/tables/tables.vue
@@ -154,6 +154,7 @@ export default {
   methods: {
     suportEdit (item, index) {
       item.render = (h, params) => {
+        this.edittingText = this.insideTableData[params.index][params.column.key]
         return h(TablesEdit, {
           props: {
             params: params,


### PR DESCRIPTION
修改当前数据，点击修改后，不修改，而是直接点击确认修改，里面的值将会制空
在编辑模式下，当数据为空时，编辑按钮不显示