### PR TITLE
Update editor.vue

### DIFF
--- a/src/components/editor/editor.vue
+++ b/src/components/editor/editor.vue
@@ -68,8 +68,3 @@ export default {
 }
 </script>
 
-<style lang="less">
-.editor-wrapper *{
-  z-index: 100 !important;
-}
-</style>


### PR DESCRIPTION
fix: 菜单栏按钮展开无法点击（内容区域在菜单按钮组上面导致）
移除  .editor-wrapper *{
  z-index: 100 !important;
}