### PR TITLE
fix tables-edit bug

### DIFF
--- a/src/components/tables/tables.vue
+++ b/src/components/tables/tables.vue
@@ -148,7 +148,8 @@ export default {
       edittingCellId: '',
       edittingText: '',
       searchValue: '',
-      searchKey: ''
+      searchKey: '',
+      isEdittingTextChange: false
     }
   },
   methods: {
@@ -164,16 +165,24 @@ export default {
           on: {
             'input': val => {
               this.edittingText = val
+              this.isEdittingTextChange = true
             },
             'on-start-edit': (params) => {
               this.edittingCellId = `editting-${params.index}-${params.column.key}`
               this.$emit('on-start-edit', params)
+              this.isEdittingTextChange = false
             },
             'on-cancel-edit': (params) => {
               this.edittingCellId = ''
               this.$emit('on-cancel-edit', params)
+              this.isEdittingTextChange = false
             },
             'on-save-edit': (params) => {
+              if (!this.isEdittingTextChange) {
+                this.edittingCellId = ''
+                this.isEdittingTextChange = false
+                return
+              }
               this.value[params.row.initRowIndex][params.column.key] = this.edittingText
               this.$emit('input', this.value)
               this.$emit('on-save-edit', Object.assign(params, { value: this.edittingText }))

--- a/src/components/tables/tables.vue
+++ b/src/components/tables/tables.vue
@@ -187,6 +187,7 @@ export default {
               this.$emit('input', this.value)
               this.$emit('on-save-edit', Object.assign(params, { value: this.edittingText }))
               this.edittingCellId = ''
+              this.edittingText = ''
             }
           }
         })


### PR DESCRIPTION
问题：1.在表格 editable 状态时，初次点击编辑 ，但是未在input上输入，点击保存 保存为空值。
          2. 当编辑一行时 点击编辑其他时，未在input上输入，点击保存 会自动编辑上一个输入的值。
          3.当编辑的内容和原来的内容相同时，没有必要触发保存时间，减少事件循环。

解决： 定义 isEdittingTextChange 字段 ，保存输入的状态，如果输入状态 为真 说明用户编辑过，可以进行下一步操作 最后并edittingText 赋值为空 ，如果为假  不作任何操作 

