### PR TITLE
fix tools function bug

### DIFF
--- a/src/libs/tools.js
+++ b/src/libs/tools.js
@@ -14,12 +14,13 @@ export const forEach = (arr, fn) => {
  * @description 得到两个数组的交集, 两个数组的元素为数值或字符串
  */
 export const getIntersection = (arr1, arr2) => {
-  let len = Math.min(arr1.length, arr2.length)
+  if (!arr1.length || !arr2.length) return []
+  let len = arr1.length
   let i = -1
   let res = []
   while (++i < len) {
-    const item = arr2[i]
-    if (arr1.indexOf(item) > -1) res.push(item)
+    const item = arr1[i]
+    if (arr2.indexOf(item) > -1) res.push(item)
   }
   return res
 }


### PR DESCRIPTION
问题：
函数getIntersection里，因为循环次数取arr1和arr2长度的最小值，但遍历的是arr2数组，如果arr2的长度大于arr1，则arr2没有被完全遍历，得到的交集不准确

解决：
固定取arr1的长度为循环次数，遍历arr1，对每个元素判断arr2中是否存在