### PR TITLE
add 'toString()' for components/tables => handleSearch function

### DIFF
--- a/src/components/tables/tables.vue
+++ b/src/components/tables/tables.vue
@@ -212,7 +212,7 @@ export default {
       if (e.target.value === '') this.insideTableData = this.value
     },
     handleSearch () {
-      this.insideTableData = this.value.filter(item => item[this.searchKey].indexOf(this.searchValue) > -1)
+      this.insideTableData = this.value.filter(item => item[this.searchKey].toString().indexOf(this.searchValue) > -1)
     },
     handleTableData () {
       this.insideTableData = this.value.map((item, index) => {


### PR DESCRIPTION
If the first column of the table component is number,  the indexOf() method will report an error.
So converting to a string type can avoid this problem.