### PR TITLE
fix: useGroup -> usegroup

### DIFF
--- a/src/components/count-to/count-to.vue
+++ b/src/components/count-to/count-to.vue
@@ -155,7 +155,7 @@ export default {
       let endVal = this.getValue(this.end)
       this.counter = new CountUp(this.counterId, this.startVal, endVal, this.decimals, this.duration, {
         useEasing: !this.uneasing,
-        useGrouping: this.useGroup,
+        useGrouping: this.usegroup,
         separator: this.separator,
         decimal: this.decimal
       })


### PR DESCRIPTION
更正拼写错误，[71行](https://github.com/iview/iview-admin/blob/master/src/components/count-to/count-to.vue#L71)是`usegroup`，[158行](https://github.com/iview/iview-admin/blob/master/src/components/count-to/count-to.vue#L158)是`useGroup`。