### PR TITLE
解决meta.access=[]时，可见菜单，但无权进入页面的BUG

### DIFF
--- a/src/libs/util.js
+++ b/src/libs/util.js
@@ -156,7 +156,7 @@ export const getNewTagList = (list, newRoute) => {
  * @param {*} route 路由列表
  */
 const hasAccess = (access, route) => {
-  if (route.meta && route.meta.access) return hasOneOf(access, route.meta.access)
+  if (route.meta && route.meta.access && route.meta.access.length) return hasOneOf(access, route.meta.access)
   else return true
 }
 


### PR DESCRIPTION
菜单权限判断和进入路由权限判断不一致，导致meta.access=[]时，菜单判断有权访问，进入路由时为无权访问